### PR TITLE
Fix spelling in protocol-redline-reset

### DIFF
--- a/protocol-redline-reset.yaml
+++ b/protocol-redline-reset.yaml
@@ -7,7 +7,7 @@ description: >
   Designed for use during acute overwhelm, dysregulation, or post-trigger spiral (e.g., OCD cleaning loop, accidental exposure, body panic).
 
 triggers:
-  - Accute physical hunger, exhaustion or shutdown
+  - Acute physical hunger, exhaustion or shutdown
   - Emotional panic, helplessness, or intrusive loops
   - Collapse in ability to prioritize or act
   - Post-trigger exhaustion with unmet basic needs (e.g., hunger, hydration)


### PR DESCRIPTION
## Summary
- fix a spelling error in the triggers section of protocol-redline-reset.yaml

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fd00216f0832ca432bc76e0412538